### PR TITLE
Change title hierarchy so allow per-year titles reflected in TOC

### DIFF
--- a/research.qmd
+++ b/research.qmd
@@ -2,8 +2,13 @@
 title: "Research"
 ---
 
-### Peer-Reviewed Publications
+## Peer-Reviewed Publications
+
+### 2024
+
 Cliff, B.Q., [Eddelbuettel, J.C.P.]{.underline}, Meiselbach, M.K., & Eisenberg, M.D. Deductible Imputation in Administrative Medical Claims Datasets. *Health Serv Res*. 2024; 1-7. [doi:10.1111/1475-6773.14278](https://doi:10.1111/1475-6773.14278)
+
+### 2023
 
 Shen, K., [Eddelbuettel, J.C.P.]{.underline}, & Eisenberg, M.D. The Impact of the COVID-19 Pandemic on Job Flows Into and Out of Healthcare. *JAMA Health Forum*. 2024; 5(1): e234964. [doi:10.1001/jamahealthforum.2023.4964](https://doi:10.1001/jamahealthforum.2023.4964)
 
@@ -19,12 +24,16 @@ Kennedy-Hendricks, A., [Eddelbuettel, J.C.P.]{.underline}, Bicket, M., Meiselbac
 
 Avery, R., Cawley, J., [Eddelbuettel, J.C.P.]{.underline}, Eisenberg, M.D., Mann, C., & Mathios, A. Consumer Responses to Firms' Voluntary Disclosure of Information: Evidence from Calorie Labeling by Starbucks. *American Journal of Health Economics*. 2023; 9(1), 22-46. [doi:10.1086/722269](https://www.journals.uchicago.edu/doi/full/10.1086/722269?casa_token=KbiK7K0tuTIAAAAA:FQVXskL7Pd92MQf-Rmwa7sTSTCG2AACbLQhFGco0D_RRRJh9S03tzlz1d4Y-GlywOChWxQp1hqU)
 
+### 2022
+
 Eisenberg, M.D., [Eddelbuettel, J.C.P.]{.underline}, & McGinty, E.E. Employment in Office Based and Intensive Behavioral Health Settings in the U.S., 2016-2021. *JAMA*. 2022; 328(16): 1642-1643. [doi:10.1001/jama.2022.17613](https://doi.org/10.1001/jama.2022.17613)
 
-### Under Review
+## Under Review
+
 [Eddelbuettel, J.C.P.]{.underline}, Kennedy-Hendricks, A., Meiselbach, M.K., Stuart, E.A., Huskamp, H.A., Busch, A.B., Hollander, M.A.G., Barry, C.L., & Eisenberg, M.D. Changes in Healthcare Spending Attributable to High Deductible Health Plan Offer Among Enrollees with Co-Morbid Substance Use Disorder and Cardiovascular Disease. *Revise & Resubmit.*
 
-### Works in Progress
+## Works in Progress
+
 Cawley, J., [Eddelbuettel, J.C.P.]{.underline}, Cunningham, S., Eisenberg, M.D., Mathios, A., & Avery, R. The Role of Repugnance in Markets: How the Jared Fogle Scandal Affected Patronage of Subway. (NBER Working Paper No. [31782](https://www.nber.org/papers/w31782))
 
 

--- a/research.qmd
+++ b/research.qmd
@@ -8,9 +8,9 @@ title: "Research"
 
 Cliff, B.Q., [Eddelbuettel, J.C.P.]{.underline}, Meiselbach, M.K., & Eisenberg, M.D. Deductible Imputation in Administrative Medical Claims Datasets. *Health Serv Res*. 2024; 1-7. [doi:10.1111/1475-6773.14278](https://doi:10.1111/1475-6773.14278)
 
-### 2023
-
 Shen, K., [Eddelbuettel, J.C.P.]{.underline}, & Eisenberg, M.D. The Impact of the COVID-19 Pandemic on Job Flows Into and Out of Healthcare. *JAMA Health Forum*. 2024; 5(1): e234964. [doi:10.1001/jamahealthforum.2023.4964](https://doi:10.1001/jamahealthforum.2023.4964)
+
+### 2023
 
 [Eddelbuettel, J.C.P.]{.underline}, & Sassler, S. State-level Policy Hostility Toward Abortion & Unplanned Births in the Pre-*Dobbs* Era. *Demography,* 2023; 60(5): 1469-1491. [doi:10.1215/00703370-10952575.](https://doi.org/10.1215/00703370-10952575)
 


### PR DESCRIPTION
This PR suggests to move the title header level down from `###` to `##` which lets us use `###` for the calendar year.  That way calendar years appear in the table of content too which is nice.

(There may be an option to have the table of content reflect more levels too, I have not checked.)